### PR TITLE
pom.xml - update cloudbees-folder version to 6.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>cloudbees-folder</artifactId>
-      <version>5.18</version>
+      <version>6.6</version>
     </dependency>
 
     


### PR DESCRIPTION
the current cloudbees-folder version, 5.18, does not work when you have a newer version of the folder plugin, such as with CloudBees  2.138 which has version 6.6 installed.

The issue that is seen without this is that if you install this plugin in CloudBees 2.138 with the Folder plugin 6.6 installed is that job do not get put under the correct folder causing the syncing not to work.